### PR TITLE
feat(action): Add action type

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: macos-11
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+
+    - name: Run tests
+      run: swift test --enable-test-discovery

--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,11 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "AsyncUI",
-            dependencies: []),
+            dependencies: []
+        ),
+        .testTarget(
+            name: "AsyncUITests",
+            dependencies: ["AsyncUI"]
+        )
     ]
 )

--- a/Sources/AsyncUI/Action/Action+AnyObject.swift
+++ b/Sources/AsyncUI/Action/Action+AnyObject.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+extension Action {
+    public convenience init<P: Publisher, I: AnyObject>(
+        canExecute: AnyPublisher<Bool, Never> = Just(true).eraseToAnyPublisher(),
+        instance: I,
+        execute: @escaping (I) -> (Input) -> P
+    ) where P.Output == Output, P.Failure == Error {
+        self.init(canExecute: canExecute) { [weak instance] input in
+            instance.map { instance in execute(instance)(input).eraseToAnyPublisher() }
+            ?? Empty().eraseToAnyPublisher()
+        }
+    }
+}

--- a/Sources/AsyncUI/Action/Action+AnyObject.swift
+++ b/Sources/AsyncUI/Action/Action+AnyObject.swift
@@ -1,14 +1,33 @@
 import Foundation
+import Combine
 
 extension Action {
-    public convenience init<P: Publisher, I: AnyObject>(
-        canExecute: AnyPublisher<Bool, Never> = Just(true).eraseToAnyPublisher(),
-        instance: I,
-        execute: @escaping (I) -> (Input) -> P
-    ) where P.Output == Output, P.Failure == Error {
-        self.init(canExecute: canExecute) { [weak instance] input in
-            instance.map { instance in execute(instance)(input).eraseToAnyPublisher() }
-            ?? Empty().eraseToAnyPublisher()
+    /// Create an action using an object function as the action
+    ///
+    /// Because we cannot reference functions using keypath you'll have to pass it as a static non instance function.
+    /// For instance `MyViewViewModel.doSomething(_:)`
+    ///
+    /// - Parameter canExecute: a signal saying whether the action is enabled or not
+    /// - Parameter object: the object to execute the action on. Action do **NOT** keep a strong reference on it.
+    public convenience init<T: AnyObject, P: Publisher, K: Publisher>(
+        object: T,
+        enabledIf: K,
+        execute: @escaping (T) -> (Input) -> P
+    ) where P.Output == Output, P.Failure == Error, K.Output == Bool, K.Failure == Never {
+        self.init(canExecute: enabledIf) { [weak object] input -> AnyPublisher<P.Output, P.Failure> in
+            guard let object = object else {
+                return Empty().eraseToAnyPublisher()
+            }
+            
+            return execute(object)(input).eraseToAnyPublisher()
         }
+    }
+    
+    public convenience init<T: AnyObject, P: Publisher, K: Publisher>(
+        object: T,
+        enabledIf enabledIfKeyPath: KeyPath<T, K>,
+        execute: @escaping (T) -> (Input) -> P
+    ) where P.Output == Output, P.Failure == Error, K.Output == Bool, K.Failure == Never {
+        self.init(object: object, enabledIf: object[keyPath: enabledIfKeyPath], execute: execute)
     }
 }

--- a/Sources/AsyncUI/Action/Action.swift
+++ b/Sources/AsyncUI/Action/Action.swift
@@ -1,0 +1,11 @@
+import Foundation
+import Combine
+
+/// An action with no input (nor output)
+public typealias Action = InputAction<Void, Void>
+
+extension Action {    
+    public func callAsFunction() {
+        self.callAsFunction(())
+    }
+}

--- a/Sources/AsyncUI/Action/Action.swift
+++ b/Sources/AsyncUI/Action/Action.swift
@@ -34,7 +34,7 @@ public class Action<Input, Output>: ObservableObject {
             .handleEvents(
                 receiveSubscription: { [weak self] _ in self?.isExecuting = true },
                 receiveCompletion: { [weak self] _ in self?.isExecuting = false },
-                receiveCancel: { [weak self] _ in self?.isExecuting = false }
+                receiveCancel: { [weak self] in self?.isExecuting = false }
             )
             .sink(
                 receiveCompletion: { [weak self] in

--- a/Sources/AsyncUI/Action/Action.swift
+++ b/Sources/AsyncUI/Action/Action.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Combine
+
+public class Action<Input, Output>: ObservableObject {
+    @Published public private(set) var canExecute: Bool = false
+    @Published public private(set) var isExecuting: Bool = false
+    @Published public private(set) var result: Result<Output, Error>?
+    
+    private let action: (Input) -> AnyPublisher<Output, Error>
+    private var cancellables: Set<AnyCancellable> = []
+    
+    public init<P: Publisher>(
+        canExecute: AnyPublisher<Bool, Never> = Just(true).eraseToAnyPublisher(),
+        execute: @escaping (Input) -> P
+    ) where P.Output == Output, P.Failure == Error {
+        self.action = { execute($0).eraseToAnyPublisher() }
+        
+        canExecute
+            .sink { [weak self] in self?.canExecute = $0 }
+            .store(in: &cancellables)
+    }
+    
+    public convenience init<T: Publisher, P: Publisher>(canExecute: T, execute: @escaping (Input) -> P)
+    where T.Output == Bool, T.Failure == Never, P.Output == Output, P.Failure == Error {
+        self.init(canExecute: canExecute.eraseToAnyPublisher(), execute: execute)
+    }
+    
+    public func callAsFunction(_ input: Input) {
+        guard canExecute && !isExecuting else {
+            return
+        }
+        
+        action(input)
+            .handleEvents(
+                receiveSubscription: { [weak self] _ in self?.isExecuting = true },
+                receiveCompletion: { [weak self] _ in self?.isExecuting = false },
+                receiveCancel: { [weak self] _ in self?.isExecuting = false }
+            )
+            .sink(
+                receiveCompletion: { [weak self] in
+                    if case .failure(let error) = $0 {
+                        self?.result = .failure(error)
+                    }
+                },
+                receiveValue: { [weak self] in self?.result = .success($0) }
+            )
+            .store(in: &cancellables)
+    }
+}

--- a/Sources/AsyncUI/Action/InputAction+AnyObject.swift
+++ b/Sources/AsyncUI/Action/InputAction+AnyObject.swift
@@ -1,33 +1,26 @@
 import Foundation
 import Combine
 
-extension Action {
+extension InputAction {
     /// Create an action using an object function as the action
     ///
     /// Because we cannot reference functions using keypath you'll have to pass it as a static non instance function.
     /// For instance `MyViewViewModel.doSomething(_:)`
     ///
     /// - Parameter canExecute: a signal saying whether the action is enabled or not
-    /// - Parameter object: the object to execute the action on. Action do **NOT** keep a strong reference on it.
+    /// - Parameter on: the object to execute the action on. Action do **NOT** keep a strong reference on it.
+    /// - Parameter execute: the object method. For instance `MyViewViewModel.doSomething(_:)`
     public convenience init<T: AnyObject, P: Publisher, K: Publisher>(
-        object: T,
-        enabledIf: K,
+        on object: T,
+        canExecute: K,
         execute: @escaping (T) -> (Input) -> P
     ) where P.Output == Output, P.Failure == Error, K.Output == Bool, K.Failure == Never {
-        self.init(canExecute: enabledIf) { [weak object] input -> AnyPublisher<P.Output, P.Failure> in
+        self.init(canExecute: canExecute) { [weak object] input -> AnyPublisher<P.Output, P.Failure> in
             guard let object = object else {
                 return Empty().eraseToAnyPublisher()
             }
             
             return execute(object)(input).eraseToAnyPublisher()
         }
-    }
-    
-    public convenience init<T: AnyObject, P: Publisher, K: Publisher>(
-        object: T,
-        enabledIf enabledIfKeyPath: KeyPath<T, K>,
-        execute: @escaping (T) -> (Input) -> P
-    ) where P.Output == Output, P.Failure == Error, K.Output == Bool, K.Failure == Never {
-        self.init(object: object, enabledIf: object[keyPath: enabledIfKeyPath], execute: execute)
     }
 }

--- a/Sources/AsyncUI/Action/InputAction.swift
+++ b/Sources/AsyncUI/Action/InputAction.swift
@@ -68,7 +68,9 @@ public class InputAction<Input, Output>: ObservableObject {
     /// - Parameter execute: the action itself to run
     public convenience init<P: Publisher>(execute: @escaping (Input) -> P) where P.Output == Output, P.Failure == Error {
         self.init(canExecute: Just(true).eraseToAnyPublisher(), execute: execute)
-        self.canExecute = true // don't wait for RunLoop.main delay
+        // don't wait for RunLoop.main delay
+        self.canExecute = true
+        self.isReadyToExecute = true
     }
 
     /// execute the action (if enabled) with given `input`.

--- a/Sources/AsyncUI/Action/InputAction.swift
+++ b/Sources/AsyncUI/Action/InputAction.swift
@@ -1,14 +1,47 @@
 import Foundation
 import Combine
 
-public class Action<Input, Output>: ObservableObject {
+/// Represents a value that accept an action taking `Input` as its input and
+/// producing an `Output` when executed.
+///
+/// Example: Create an action running only if user has permission
+///
+/// ```swift
+/// class SomeClass: ObservableObject {
+///     var deleteNote: Action<Void, Void>!
+///     @Published var isUserAdmin = false
+///
+///     init() {
+///         self.deleteNote = Action(canExecute: $isUserAdmin) { [weak self] in
+///             self?.delete(note: $0)
+///         }
+///     }
+///
+///     func delete(note: Note) -> AnyPublisher<Void, Error> {
+///         /// delete the note
+///     }
+/// }
+/// ```
+///
+/// Alternatively you can also pass the object and its instance method in order to avoid using `weak` everytime:
+///
+/// ```swift
+///     self.deleteNote = Action(on: self, canExecute: $isUserAdmin, execute: SomeClass.deleteNote(note:))
+/// ```
+public class InputAction<Input, Output>: ObservableObject {
+    /// true if the action is can be executed. Has no effect if chaning *while* the action is already running
     @Published public private(set) var canExecute: Bool = false
+    /// true if the action is currently running
     @Published public private(set) var isExecuting: Bool = false
+    /// the last result from the action
     @Published public private(set) var result: Result<Output, Error>?
     
     private let action: (Input) -> AnyPublisher<Output, Error>
     private var cancellables: Set<AnyCancellable> = []
     
+    /// init the action by supplying when it is enabled or not and the closure to run
+    /// - Parameter canExecute: a publisher indicating whenever the action is enabled or not
+    /// - Parameter execute: the action itself to run
     public init<K: Publisher, P: Publisher>(canExecute: K, execute: @escaping (Input) -> P)
     where K.Output == Bool, K.Failure == Never, P.Output == Output, P.Failure == Error {
         
@@ -19,12 +52,15 @@ public class Action<Input, Output>: ObservableObject {
             .store(in: &cancellables)
     }
     
+    /// Convenience init to use when the action should always be enabled
+    /// - Parameter execute: the action itself to run
     public convenience init<P: Publisher>(execute: @escaping (Input) -> P) where P.Output == Output, P.Failure == Error {
         self.init(canExecute: Just(true).eraseToAnyPublisher(), execute: execute)
     }
-    
-    
-    
+
+    /// execute the action (if enabled) with given `input`.
+    ///
+    /// This is a special Swift method which can be called as regular function on the object.
     public func callAsFunction(_ input: Input) {
         guard canExecute && !isExecuting else {
             return

--- a/Tests/AsyncUITests/Action/InputActionTests.swift
+++ b/Tests/AsyncUITests/Action/InputActionTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+import AsyncUI
+import Combine
+
+class InputActionTests: XCTestCase {
+    func test_canExecute_notDefinedAtInit_returnTrue() {
+        let action = Action {
+            Empty()
+        }
+        
+        XCTAssertTrue(action.canExecute)
+    }
+    
+    func test_execute_callMultipleTimes_executeOnlyOnce() {
+        let expectation = XCTestExpectation()
+        let nonFinishingPublisher = PassthroughSubject<Void, Error>()
+        let action = Action { () -> PassthroughSubject<Void, Error> in
+            expectation.fulfill()
+            return nonFinishingPublisher
+        }
+        
+        action()
+        action()
+        
+        expectation.assertForOverFulfill = true
+        wait(for: [expectation], timeout: 1)
+    }
+}

--- a/Tests/AsyncUITests/Action/InputActionTests.swift
+++ b/Tests/AsyncUITests/Action/InputActionTests.swift
@@ -25,4 +25,15 @@ class InputActionTests: XCTestCase {
         expectation.assertForOverFulfill = true
         wait(for: [expectation], timeout: 1)
     }
+    
+    func test_execute_actionIsMarkedAsExecuting() {
+        let nonFinishingPublisher = PassthroughSubject<Void, Error>()
+        let action = Action { () -> PassthroughSubject<Void, Error> in
+            return nonFinishingPublisher
+        }
+        
+        action()
+        
+        XCTAssertTrue(action.isExecuting)
+    }
 }


### PR DESCRIPTION
Add `Action` to execute arbitrary asynchronous code:

- `canExecute` attribute allow to define when the action should be on/off
- `isExecuting` allow to avoid executing the action twice in parallel